### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/toku345/kakko-de/security/code-scanning/1](https://github.com/toku345/kakko-de/security/code-scanning/1)

To fix the problem, add a `permissions` block at the workflow or job level to explicitly restrict the GITHUB_TOKEN’s permissions following the principle of least privilege. Since the current workflow only appears to need read access to repository contents (to checkout code and read files), it is sufficient to set `permissions: contents: read` at the workflow root. This change applies minimal permissions to all jobs (currently, there's only one). Place the new block at the top-level of the workflow file, after the `name` and before `on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
