### PR TITLE
refactor: move error handling responsibility to individual tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Evaluate the `def` forms to override settings at runtime.
 
 - **Tool-level error handling:** Each tool wrapper function (e.g., `read-file`, `write-file`) handles its own domain-specific errors
 - **Result map pattern:** `{:success true/false ...}` instead of throwing
-- **Descriptive errors for LLM:** Error messages should help LLM agents decide next actions (e.g., "File not found: /path" vs generic "Tool execution failed")
+- **Descriptive errors for LLM:** Error messages should help LLM agents decide next actions (e.g., "Failed to read file: /path - No such file or directory" vs generic "Tool execution failed")
 - **Fallback boundary:** `execute-tool` catches unexpected exceptions as a safety net
 
 ## Schema Validation (Malli)

--- a/src/coder_agent/protocols.clj
+++ b/src/coder_agent/protocols.clj
@@ -5,10 +5,12 @@
   "Protocol for file system operations."
   (write-file! [this path content]
     "Writes content to a file at the specified path.
-     Returns a ResultMap: {:success true :file_path path} or {:success false :error msg}")
+     Returns a ResultMap: {:success true :file_path path} on success.
+     May throw Exception on failure (e.g., IOException, SecurityException).")
   (read-file! [this path]
     "Reads content from a file at the specified path.
-     Returns a ResultMap: {:success true :content content} or {:success false :error msg}"))
+     Returns a ResultMap: {:success true :content content} on success.
+     May throw Exception on failure (e.g., IOException, SecurityException)."))
 
 (defprotocol LLMClient
   "Protocol for LLM API integrations."

--- a/src/coder_agent/tools.clj
+++ b/src/coder_agent/tools.clj
@@ -19,9 +19,7 @@
   [{:keys [file_path content]} & {:keys [fs] :or {fs default-fs}}]
   (try
     (write-file! fs file_path content)
-    (catch java.security.AccessControlException e
-      {:success false :error (str "Failed to write file: " file_path " - " (.getMessage e))})
-    (catch java.io.IOException e
+    (catch Exception e
       {:success false :error (str "Failed to write file: " file_path " - " (.getMessage e))})))
 
 (def write-tool
@@ -40,7 +38,7 @@
   [{:keys [file_path]} & {:keys [fs] :or {fs default-fs}}]
   (try
     (read-file! fs file_path)
-    (catch java.io.IOException e
+    (catch Exception e
       {:success false :error (str "Failed to read file: " file_path " - " (.getMessage e))})))
 
 (def read-tool

--- a/test/coder_agent/tools_test.clj
+++ b/test/coder_agent/tools_test.clj
@@ -87,6 +87,16 @@
       (is (false? (:success result)))
       (is (= "Failed to read file: missing.txt - File not found: missing.txt" (:error result)))))
 
+  (testing "read-file returns error on permission denied"
+    (let [failing-fs
+          #_{:clj-kondo/ignore [:missing-protocol-method]}
+          (reify FileSystem
+            (read-file! [_ path]
+              (throw (java.security.AccessControlException. (str "Permission denied: " path)))))
+          result (tools/read-file {:file_path "/protected/secret.txt"} :fs failing-fs)]
+      (is (false? (:success result)))
+      (is (= "Failed to read file: /protected/secret.txt - Permission denied: /protected/secret.txt" (:error result)))))
+
   (testing "read-file returns error on IO failure"
     (let [failing-fs
           #_{:clj-kondo/ignore [:missing-protocol-method]}


### PR DESCRIPTION
## Summary

- Each tool wrapper function (`read-file`, `write-file`) now handles its own domain-specific errors
- Unified to use `catch Exception` for simpler and more robust error handling
- Error messages include details to help LLM agents decide next actions

## Changes

- `read-file`: uses `catch Exception` (handles all exception types)
- `write-file`: uses `catch Exception` (simplified from multiple catch clauses)
- Updated `FileSystem` protocol docstrings to document "may throw" behavior
- Updated CLAUDE.md error example to match actual implementation format
- Added `read-file` permission denied test for `AccessControlException`

## Test plan

- [x] `clj -X:test` passes (10 tests, 56 assertions)
- [x] `clj -M:lint` passes (0 errors, 0 warnings)
- [x] `clj -M:fmt/check` passes

Closes #22
