### PR TITLE
chore: add explicit cljfmt configuration

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,0 +1,6 @@
+{:indentation? true
+ :remove-surrounding-whitespace? true
+ :remove-trailing-whitespace? true
+ :remove-consecutive-blank-lines? true
+ :insert-missing-whitespace? true
+ :remove-multiple-non-indenting-spaces? false}


### PR DESCRIPTION
## Summary

- Add `.cljfmt.edn` to unify code formatting between CLI and VS Code

## Problem

`clj -M:fmt/check` and VS Code Calva auto-formatter used different settings, causing format inconsistencies that were not caught until CI.

## Solution

Explicit `.cljfmt.edn` configuration file that both tools will read:
- CLI: `clj -M:fmt/check` / `clj -M:fmt/fix`
- VS Code: Calva formatter

## Test plan

- [x] `clj -M:fmt/check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)