### PR TITLE
test: add spy tracking to read-file! in MockFileSystem

### DIFF
--- a/test/coder_agent/tools_test.clj
+++ b/test/coder_agent/tools_test.clj
@@ -11,9 +11,10 @@
 (defrecord MockFileSystem [calls]
   FileSystem
   (write-file! [_ path content]
-    (swap! calls conj {:path path :content content})
+    (swap! calls conj {:op :write-file :path path :content content})
     {:success true :file_path path})
   (read-file! [_ path]
+    (swap! calls conj {:op :read-file :path path})
     (let [content (str "Mock content of " path)]
       {:success true :content content})))
 
@@ -75,13 +76,14 @@
     (let [fs (mock-fs)
           result (tools/write-file {:file_path "test.txt" :content "hello"} :fs fs)]
       (is (= {:success true :file_path "test.txt"} result))
-      (is (= [{:path "test.txt" :content "hello"}] @(:calls fs))))))
+      (is (= [{:op :write-file :path "test.txt" :content "hello"}] @(:calls fs))))))
 
 (deftest read-file-test
   (testing "read-file delegates to FileSystem protocol"
     (let [fs (mock-fs)
           result (tools/read-file {:file_path "test.txt"} :fs fs)]
-      (is (= {:success true :content "Mock content of test.txt"} result)))))
+      (is (= {:success true :content "Mock content of test.txt"} result))
+      (is (= [{:op :read-file :path "test.txt"}] @(:calls fs))))))
 
 ;; === Tool Dispatcher Tests ===
 


### PR DESCRIPTION
- Add :op key to both write-file! and read-file! spy records for consistency
- Update read-file-test to verify spy calls
- Unify spy format across all MockFileSystem operations