### PR TITLE
docs: clarify underscore naming convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Evaluate the `def` forms to override settings at runtime.
 ## Notes
 
 - openai-clojure uses `:api-endpoint` (not `:base-url`) for custom endpoints
-- `tool-registry` keys must match the `:name` in tool definitions (e.g., `"list_dir"` in both). Note that tool names use underscores (OpenAI convention) while Clojure functions use hyphens (`list-dir`). A mismatch causes `execute-tool` to return "Unknown tool" error since dispatch is by name.
+- `tool-registry` keys must match the `:name` in tool definitions (e.g., `"list_dir"` in both). Tool names use underscores (OpenAI convention) while Clojure functions use hyphens (`list-dir`). Mismatches cause `execute-tool` to return "Unknown tool" error since dispatch is by name.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Clarify underscore/hyphen naming convention in tool-registry documentation
- OpenAI uses snake_case (`list_dir`) while Clojure uses kebab-case (`list-dir`)
- Prevents bugs from naming convention mismatches when adding new tools

## Test plan

- [x] Documentation change only - no code changes
- [x] Format check passed

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)