### PR TITLE
refactor(core): simplify chat function and decouple I/O

### DIFF
--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -25,7 +25,7 @@
    :on-tool-execution output/print-tool-execution})
 
 (defn- safe-invoke
-  "Invoke callback safely, logging errors but not propagating them."
+  "Invoke callback safely, printing warnings on error but not propagating them."
   [callback & args]
   (when callback
     (try
@@ -34,27 +34,23 @@
         (println (str "Warning: callback failed - " (.getMessage e)))))))
 
 (defn format-tool-result-message
-  "Convert tool execution result to OpenAI message format."
   [tool-call result]
   {:role "tool"
    :tool_call_id (:id tool-call)
    :content (json/generate-string result)})
 
 (defn build-initial-messages
-  "Build initial message list from system prompt and user input."
   [system-prompt user-input]
   [{:role "system" :content system-prompt}
    {:role "user" :content user-input}])
 
 (defn append-turn
-  "Append assistant message and tool results to message history."
   [messages assistant-message tool-results]
   (-> messages
       (conj assistant-message)
       (into tool-results)))
 
 (defn has-tool-calls?
-  "Check if LLM response message contains tool calls."
   [message]
   (seq (:tool_calls message)))
 
@@ -62,7 +58,7 @@
   "Execute one LLM round-trip. Decoupled from loop control.
    Returns:
      {:status :continue :messages [...]} - continue with updated messages
-     {:status :complete :content ...}    - final content"
+     {:status :complete :content ...}    - final content (may be nil)"
   [client messages & {:keys [model tools execute-tool-fn on-tool-execution]
                       :or {model default-model
                            tools available-tools

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -12,8 +12,8 @@
 
 (def available-tools [tools/write-tool tools/read-tool tools/list-dir-tool])
 
-(def system-prompt
-  "System prompt for the AI assistant."
+(def default-system-prompt
+  "Default system prompt for the AI assistant."
   "You are a helpful coding assistant. Use the provided tools to assist with coding tasks.")
 
 (def default-client
@@ -80,12 +80,14 @@
      :execute-tool-fn - Function to execute tools (default: tools/execute-tool)
      :tools           - Available tools (default: available-tools)
      :model           - Model name (default: default-model)
-     :max-iterations  - Max tool loop iterations (default: 30)"
-  [client user-input & {:keys [execute-tool-fn tools model max-iterations]
+     :max-iterations  - Max tool loop iterations (default: 30)
+     :system-prompt   - System prompt (default: default-system-prompt)"
+  [client user-input & {:keys [execute-tool-fn tools model max-iterations system-prompt]
                         :or {execute-tool-fn tools/execute-tool
                              tools available-tools
                              model default-model
-                             max-iterations 30}}]
+                             max-iterations 30
+                             system-prompt default-system-prompt}}]
   (println "🤖 Thinking with tools..")
   (loop [messages (build-initial-messages system-prompt user-input)
          iteration 0]

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -13,7 +13,6 @@
 (def available-tools [tools/write-tool tools/read-tool tools/list-dir-tool])
 
 (def default-system-prompt
-  "Default system prompt for the AI assistant."
   "You are a helpful coding assistant. Use the provided tools to assist with coding tasks.")
 
 (def default-client
@@ -97,8 +96,8 @@
      :model             - Model name (default: default-model)
      :max-iterations    - Max tool loop iterations (default: 30)
      :system-prompt     - System prompt (default: default-system-prompt)
-     :on-thinking       - Callback when thinking starts (default: prints emoji)
-     :on-tool-execution - Callback (fn [tool-call result]) after tool execution (default: print-tool-execution)"
+     :on-thinking       - Callback when thinking starts. Pass nil to disable. (default: prints emoji)
+     :on-tool-execution - Callback (fn [tool-call result]) after tool execution. Pass nil to disable. (default: print-tool-execution)"
   [client user-input & {:keys [execute-tool-fn tools model max-iterations system-prompt
                                on-thinking on-tool-execution]
                         :or {execute-tool-fn tools/execute-tool

--- a/test/coder_agent/core_test.clj
+++ b/test/coder_agent/core_test.clj
@@ -24,7 +24,7 @@
       (core/chat mock-client "What is Clojure?")
       (is (= "system"
              (-> @captured-request :messages first :role)))
-      (is (= core/system-prompt
+      (is (= core/default-system-prompt
              (-> @captured-request :messages first :content)))
       (is (= "What is Clojure?"
              (-> @captured-request :messages second :content)))))

--- a/test/coder_agent/core_test.clj
+++ b/test/coder_agent/core_test.clj
@@ -80,27 +80,39 @@
   (testing "returns :continue when tool calls present"
     (let [mock-client (llm/make-mock-client
                        (fn [_request]
-                         {:choices [{:message {:tool_calls [{:id "1"
+                         {:choices [{:message {:role "assistant"
+                                               :tool_calls [{:id "tc1"
                                                              :function {:name "read_file"
                                                                         :arguments "{}"}}]}}]}))
           result (core/chat-step mock-client
                                  [{:role "user" :content "Write"}]
                                  :execute-tool-fn (constantly {:success true})
+                                 :on-tool-execution nil)
+          msg (:messages result)]
+      (is (= :continue (:status result)))
+      (is (= 3 (count msg)))
+      (is (= "user" (:role (first msg))))
+      (is (= "assistant" (:role (second msg))))
+      (is (= "tool" (:role (nth msg 2))))
+      (is (= "tc1" (:tool_call_id (nth msg 2))))))
+
+  (testing "handles multiple tool calls in single response"
+    (let [executed-tools (atom [])
+          mock-client (llm/make-mock-client
+                       (fn [_request]
+                         {:choices [{:message {:tool_calls
+                                               [{:id "tc1" :function {:name "read_file" :arguments "{}"}}
+                                                {:id "tc2" :function {:name "list_dir" :arguments "{}"}}]}}]}))
+          mock-execute (fn [tc]
+                         (swap! executed-tools conj (:id tc))
+                         {:success true})
+          result (core/chat-step mock-client
+                                 [{:role "user" :content "Multi"}]
+                                 :execute-tool-fn mock-execute
                                  :on-tool-execution nil)]
       (is (= :continue (:status result)))
-      (is (vector? (:messages result)))))
-
-  (testing "handles nil on-tool-execution without error"
-    (let [mock-client (llm/make-mock-client
-                       (fn [_request]
-                         {:choices [{:message {:tool_calls [{:id "1"
-                                                             :function {:name "write_file"
-                                                                        :arguments "{}"}}]}}]}))
-          result (core/chat-step mock-client
-                                 [{:role "user" :content "Write"}]
-                                 :execute-tool-fn (constantly {:success true})
-                                 :on-tool-execution nil)]
-      (is (some? result))))
+      (is (= ["tc1" "tc2"] @executed-tools))
+      (is (= 4 (count (:messages result))))))
 
   (testing "survives callback exception via safe-invoke"
     (let [mock-client (llm/make-mock-client
@@ -114,3 +126,19 @@
                                  :execute-tool-fn (constantly {:success true})
                                  :on-tool-execution faulty-callback)]
       (is (some? result)))))
+
+(deftest format-tool-result-message-test
+  (testing "formats successful tool result correctly"
+    (let [tool-call {:id "call_123" :function {:name "read_file"}}
+          result {:success true :content "file contents"}
+          msg (core/format-tool-result-message tool-call result)]
+      (is (= "tool" (:role msg)))
+      (is (= "call_123" (:tool_call_id msg)))
+      (is (= (json/generate-string result) (:content msg)))))
+
+  (testing "formats failed tool result correctly"
+    (let [tool-call {:id "call_456" :function {:name "write_file"}}
+          result {:success false :error "Permission denied"}
+          msg (core/format-tool-result-message tool-call result)]
+      (is (= "tool" (:role msg)))
+      (is (string? (:content msg))))))


### PR DESCRIPTION
## Summary

- Refactor `chat` and `chat-step` functions to improve testability and decouple I/O from domain logic
- Make `system-prompt` injectable via `:system-prompt` option
- Abstract output via callback handlers (`:on-thinking`, `:on-tool-execution`)

### Changes

1. **Extract helper functions** (`9aeb1e8`)
   - `format-tool-result-message`, `build-initial-messages`, `append-turn`, `has-tool-calls?`

2. **Make system-prompt injectable** (`63721d2`)
   - Rename `system-prompt` to `default-system-prompt`
   - Add `:system-prompt` option to `chat` function

3. **Abstract output via callbacks** (`676b310`)
   - Add `default-output-handlers` map
   - Add `:on-thinking` and `:on-tool-execution` options
   - Replace hardcoded `println` and `output/print-tool-execution` with callbacks

4. **Add safe-invoke for callback exception handling** (`a44185a`)
   - Wrap callback invocations to prevent exceptions from crashing the chat loop
   - Log warnings for failed callbacks without propagating errors

5. **Add chat-step unit tests** (`276d1b7`)
   - Test `:complete`/`:continue` return values
   - Test nil callback handling
   - Test callback exception survival via safe-invoke

6. **Improve docstrings** (`169de81`)
   - Document "Pass nil to disable" for callback options
   - Remove redundant docstring from `default-system-prompt`

7. **Strengthen chat-step test coverage** (`1c7d6dd`)
   - Add multiple tool calls test
   - Add `format-tool-result-message` direct tests
   - Strengthen message structure validation (role, order, tool_call_id)
   - Remove redundant nil callback test

8. **Improve docstrings per CLAUDE.md guidelines** (`6ee5000`)
   - Remove redundant "What" docstrings from helper functions
   - Fix safe-invoke docstring (logging → printing warnings)
   - Clarify chat-step return value may be nil

### Motivation

Based on Rich Hickey "Simple Made Easy" review, this PR resolves detected **complecting**:
- ✅ Configuration vs Logic separation (`system-prompt` now injectable)
- ✅ I/O vs Domain logic separation (output via callbacks)
- ✅ Callback safety (exceptions don't crash chat loop)

## Test plan

- [x] Run `clj -X:test` - all 33 tests pass (209 assertions)
- [x] REPL verification with custom callbacks:
  ```clojure
  (chat client "test" :on-thinking nil :on-tool-execution nil)
  (chat client "test" :system-prompt "Custom prompt")
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

