### PR TITLE
feat(llm): replace openai-clojure with direct HTTP client

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -5,7 +5,9 @@
 # API Key (required)
 export OPENAI_API_KEY=sk-your-api-key
 
-# API Endpoint (optional - omit for default OpenAI API)
+# API Endpoint (required)
+# For OpenAI API:
+# export OPENAI_API_ENDPOINT=https://api.openai.com/v1
 # For local LLM (e.g., vLLM, Ollama):
 # export OPENAI_API_ENDPOINT=http://localhost:8000/v1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,14 @@ clj -M:fmt/fix     # Auto-fix formatting
 ```
 
 **Error Message Guidelines:**
+
 - Include operation context: `"Failed to read file:"`
 - Include the path/resource: `/path/to/file`
 - Include the cause: `No such file or directory`
 - Help LLM agents decide next actions
 
 **Exception Boundaries:**
+
 - Protocol implementations catch domain errors, return ResultMaps
 - `execute-tool` is the fallback boundary for unexpected exceptions
 
@@ -114,12 +116,12 @@ clj -M:fmt/fix     # Auto-fix formatting
 ## Environment Variables
 
 | Variable | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | `OPENAI_API_ENDPOINT` | API endpoint | (required) |
 | `OPENAI_API_KEY` | API key | `sk-dummy` |
 | `OPENAI_MODEL` | Model name | `gpt-5-mini` |
 | `DEBUG` | Enable debug logging | `false` |
-| `ECHO` | Show internal prompt (vLLM echo mode) | `false` |
+| `ECHO` | Show internal prompt (vLLM only, causes error on OpenAI API) | `false` |
 
 Setup: `cp .envrc.example .envrc && direnv allow`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ clj
 # Run unit tests (default, excludes integration)
 clj -X:test
 
-# Run integration tests only (requires OPENAI_API_KEY)
+# Run integration tests only (requires OPENAI_API_ENDPOINT)
 clj -X:test :excludes '[]' :includes '[:integration]'
 
 # Run all tests
@@ -115,16 +115,16 @@ clj -M:fmt/fix     # Auto-fix formatting
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `OPENAI_API_KEY` | API key | (required) |
-| `OPENAI_API_ENDPOINT` | API endpoint | OpenAI default |
+| `OPENAI_API_ENDPOINT` | API endpoint | (required) |
+| `OPENAI_API_KEY` | API key | `sk-dummy` |
 | `OPENAI_MODEL` | Model name | `gpt-5-mini` |
 | `DEBUG` | Enable debug logging | `false` |
+| `ECHO` | Show internal prompt (vLLM echo mode) | `false` |
 
 Setup: `cp .envrc.example .envrc && direnv allow`
 
 ## Important Notes
 
-- openai-clojure uses `:api-endpoint` (not `:base-url`) for custom endpoints
 - `tool-registry` keys must match `:name` in tool definitions exactly
 - Tool names use underscores (OpenAI convention), Clojure functions use hyphens
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps
  {org.clojure/clojure {:mvn/version "1.12.4"}
   net.clojars.wkok/openai-clojure {:mvn/version "0.23.0"}
+  org.clj-commons/clj-http-lite {:mvn/version "1.0.13"}
   cheshire/cheshire {:mvn/version "6.1.0"}
   metosin/malli {:mvn/version "0.20.0"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:deps
  {org.clojure/clojure {:mvn/version "1.12.4"}
-  net.clojars.wkok/openai-clojure {:mvn/version "0.23.0"}
   org.clj-commons/clj-http-lite {:mvn/version "1.0.13"}
   cheshire/cheshire {:mvn/version "6.1.0"}
   metosin/malli {:mvn/version "0.20.0"}}

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -152,4 +152,4 @@
                                               :content "What is Clojure?"}]
                                   :echo true}))
 
-  (:prompt_logprobs response))
+  (debug/log-internal-prompt (:prompt_logprobs response)))

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -124,9 +124,10 @@
         :complete (:content result)))))
 
 (defn -main [& args]
-  (let [input (first args)]
+  (let [input (first args)
+        echo? (= "true" (System/getenv "ECHO"))]
     (if input
-      (println "Answer:" (chat @default-client input :echo true))
+      (println "Answer:" (chat @default-client input :echo echo?))
       (println "Please input your question as the first argument."))))
 
 (comment

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -4,7 +4,8 @@
             [coder-agent.llm :as llm]
             [coder-agent.tools :as tools]
             [coder-agent.debug :as debug]
-            [coder-agent.output :as output]))
+            [coder-agent.output :as output]
+            [clojure.string :as str]))
 
 (def default-model
   (or (System/getenv "OPENAI_MODEL")
@@ -125,7 +126,7 @@
 
 (defn -main [& args]
   (let [input (first args)
-        echo? (= "true" (System/getenv "ECHO"))]
+        echo? (some-> (System/getenv "ECHO") str/lower-case (= "true"))]
     (if input
       (println "Answer:" (chat @default-client input :echo echo?))
       (println "Please input your question as the first argument."))))

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -17,7 +17,7 @@
   "You are a helpful coding assistant. Use the provided tools to assist with coding tasks.")
 
 (def default-client
-  "Default LLM client created from environment variables."
+  "Default LLM client. Uses OPENAI_API_ENDPOINT env var; api-key defaults to sk-dummy."
   (delay (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT"))))
 
 (def default-output-handlers
@@ -98,7 +98,8 @@
      :max-iterations    - Max tool loop iterations (default: 30)
      :system-prompt     - System prompt (default: default-system-prompt)
      :on-thinking       - Callback when thinking starts. Pass nil to disable. (default: prints emoji)
-     :on-tool-execution - Callback (fn [tool-call result]) after tool execution. Pass nil to disable. (default: print-tool-execution)"
+     :on-tool-execution - Callback (fn [tool-call result]) after tool execution. Pass nil to disable. (default: print-tool-execution)
+     :echo              - Enable echo mode for vLLM internal prompt logging (default: false)"
   [client user-input & {:keys [execute-tool-fn tools model max-iterations system-prompt
                                on-thinking on-tool-execution echo]
                         :or {execute-tool-fn tools/execute-tool

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -17,7 +17,7 @@
 
 (def default-client
   "Default LLM client created from environment variables."
-  (delay (llm/make-openai-client)))
+  (delay (llm/make-vllm-client (System/getenv "OPENAI_API_ENDPOINT"))))
 
 (def default-output-handlers
   "Default output handlers for chat functions."
@@ -126,7 +126,7 @@
 (defn -main [& args]
   (let [input (first args)]
     (if input
-      (println "Answer:" (chat @default-client input))
+      (println "Answer:" (chat @default-client input :echo true))
       (println "Please input your question as the first argument."))))
 
 (comment

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -134,3 +134,16 @@
         :model "Qwen/Qwen3-Coder-30B-A3B-Instruct")
   (chat client "Read the number from test_output_count.txt and increment it by 1, then write it back."
         :model "Qwen/Qwen3-Coder-30B-A3B-Instruct"))
+
+(comment
+  (def vllm-client (llm/make-vllm-client "http://localhost:8000/v1"))
+
+  (def response (chat-completion vllm-client
+                                 {:model "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+                                  :messages [{:role "system"
+                                              :content "You are a helpful coding assistant."}
+                                             {:role "user"
+                                              :content "What is Clojure?"}]
+                                  :echo true}))
+
+  (:prompt_logprobs response))

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -17,8 +17,10 @@
   "You are a helpful coding assistant. Use the provided tools to assist with coding tasks.")
 
 (def default-client
-  "Default LLM client. Uses OPENAI_API_ENDPOINT env var; api-key defaults to sk-dummy."
-  (delay (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT"))))
+  "Default LLM client. Uses OPENAI_API_ENDPOINT and OPENAI_API_KEY env vars."
+  (delay (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT")
+                                 :api-key (or (System/getenv "OPENAI_API_KEY")
+                                              "sk-dummy"))))
 
 (def default-output-handlers
   "Default output handlers for chat functions."

--- a/src/coder_agent/core.clj
+++ b/src/coder_agent/core.clj
@@ -17,7 +17,7 @@
 
 (def default-client
   "Default LLM client created from environment variables."
-  (delay (llm/make-vllm-client (System/getenv "OPENAI_API_ENDPOINT"))))
+  (delay (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT"))))
 
 (def default-output-handlers
   "Default output handlers for chat functions."
@@ -143,7 +143,7 @@
         :model "Qwen/Qwen3-Coder-30B-A3B-Instruct"))
 
 (comment
-  (def vllm-client (llm/make-vllm-client "http://localhost:8000/v1"))
+  (def vllm-client (llm/make-openai-client "http://localhost:8000/v1"))
 
   (def response (chat-completion vllm-client
                                  {:model "Qwen/Qwen3-Coder-30B-A3B-Instruct"

--- a/src/coder_agent/debug.clj
+++ b/src/coder_agent/debug.clj
@@ -197,3 +197,29 @@
     (-> (extract-tool-execution-summary tool-call result)
         format-tool-execution-summary
         output-fn)))
+
+(defn extract-internal-prompt
+  "Extract internal prompt text from vLLM prompt_logprobs.
+   Each item contains a map with token info including :decoded_token."
+  [prompt-logprobs]
+  (->> prompt-logprobs
+       (remove nil?)
+       (mapcat (fn [item]
+                 (map (fn [[_ v]] (:decoded_token v)) item)))
+       (apply str)))
+
+(defn format-internal-prompt
+  "Format internal prompt for log output."
+  [prompt-logprobs]
+  (str "\n========== INTERNAL PROMPT ==========\n"
+       (extract-internal-prompt prompt-logprobs)
+       "\n=====================================\n"))
+
+(defn log-internal-prompt
+  "Log internal prompt unconditionally (not tied to DEBUG)
+   Options:
+     :output-fn - Output function (default: println)"
+  [prompt-logprobs & {:keys [output-fn]
+                      :or {output-fn println}}]
+  (when (seq prompt-logprobs)
+    (output-fn (format-internal-prompt prompt-logprobs))))

--- a/src/coder_agent/llm.clj
+++ b/src/coder_agent/llm.clj
@@ -27,12 +27,17 @@
                                              "Content-Type" "application/json"}
                                    :body (json/generate-string request)
                                    :throw-exceptions true
+                                   ;; socket-timeout is longer to accommodate LLM generation latency
                                    :conn-timeout 10000
                                    :socket-timeout 60000})]
           (json/parse-string (:body response) true))
         (catch Exception e
           (throw (ex-info "LLM API request failed"
-                          {:url url :cause (.getMessage e)} e)))))))
+                          {:url url
+                           :model (:model request)
+                           :message-count (count (:messages request))
+                           :exception-type (type e)
+                           :cause (.getMessage e)} e)))))))
 
 (defn make-openai-client
   "Create an OpenAIClient for OpenAI-compatible endpoints

--- a/test/coder_agent/integration_test.clj
+++ b/test/coder_agent/integration_test.clj
@@ -6,6 +6,8 @@
 
 (deftest ^:integration real-api-test
   (testing "Real API call returns non-empty response."
+    (is (some? (System/getenv "OPENAI_API_ENDPOINT"))
+        "OPENAI_API_ENDPOINT must be set for integration tests.")
     (is (some? (System/getenv "OPENAI_API_KEY"))
         "OPENAI_API_KEY must be set for integration tests.")
     (let [client (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT")

--- a/test/coder_agent/integration_test.clj
+++ b/test/coder_agent/integration_test.clj
@@ -8,7 +8,8 @@
   (testing "Real API call returns non-empty response."
     (is (some? (System/getenv "OPENAI_API_KEY"))
         "OPENAI_API_KEY must be set for integration tests.")
-    (let [client (llm/make-openai-client)
+    (let [client (llm/make-openai-client (System/getenv "OPENAI_API_ENDPOINT")
+                                         :api-key (System/getenv "OPENAI_API_KEY"))
           response (core/chat client "Say hello in one word.")]
       (is (string? response))
       (is (pos? (count response))))))

--- a/test/coder_agent/llm_test.clj
+++ b/test/coder_agent/llm_test.clj
@@ -1,0 +1,26 @@
+(ns coder-agent.llm-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [coder-agent.llm :as llm]
+            [coder-agent.test-helper :as helper]))
+
+(use-fixtures :once helper/with-instrumentation)
+
+(deftest make-openai-client-test
+  (testing "throws when api-endpoint is nil"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"API endpoint is required"
+                          (llm/make-openai-client nil))))
+
+  (testing "throws when api-endpoint is blank"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"API endpoint is required"
+                          (llm/make-openai-client "   "))))
+
+  (testing "uses default api-key when not provided"
+    (let [client (llm/make-openai-client "http://localhost:8000/v1")]
+      (is (= "sk-dummy" (:api-key client)))))
+
+  (testing "uses custom api-key when provided"
+    (let [client (llm/make-openai-client "http://localhost:8000/v1"
+                                         :api-key "custom-key")]
+      (is (= "custom-key" (:api-key client))))))


### PR DESCRIPTION
## Summary

- Replace openai-clojure with direct HTTP client using clj-http-lite
- Preserve vLLM-specific fields like prompt_logprobs (not filtered by library)
- Add internal prompt display feature for debugging chat template behavior
- Control echo mode via ECHO environment variable

## Changes

- deps.edn: Replace openai-clojure with clj-http-lite (GraalVM Native Image compatible)
- llm.clj: New OpenAIClient using direct HTTP requests with improved error context
- debug.clj: Add extract-internal-prompt, format-internal-prompt, log-internal-prompt
- core.clj: Add :echo option, read OPENAI_API_KEY env var, improve docstrings
- AGENTS.md: Update environment variables documentation
- .envrc.example: Add OpenAI API endpoint example
- llm_test.clj: Add validation tests for make-openai-client

## Usage

```bash
# Normal execution
clj -M:run "What is Clojure?"

# With internal prompt display (vLLM only)
ECHO=true clj -M:run "What is Clojure?"
```

## Test plan

- [x] clj -M:lint passes
- [x] clj -M:fmt/check passes
- [x] clj -X:test passes (34 tests, 215 assertions)
- [x] Manual test with vLLM server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
